### PR TITLE
Set nonInteractive on format command

### DIFF
--- a/hdfs-namenode/run-namenode.sh
+++ b/hdfs-namenode/run-namenode.sh
@@ -92,7 +92,7 @@ if [ -z "$STANDBY" ]; then
 
     if [ ! -f $NAMENODE_FORMATTED_FLAG ]; then
         echo "Formatting namenode..."
-        gosu hdfs hdfs namenode -format -clusterId $CLUSTER_NAME
+        gosu hdfs hdfs namenode -format -nonInteractive -clusterId $CLUSTER_NAME
         touch $NAMENODE_FORMATTED_FLAG
     fi
 fi


### PR DESCRIPTION
If the container is deleted and recreated and the volume reused, the flag for already formatted doesn't exist, the format reruns, and then repeatedly tries to prompt for permission to format over existing directories.

This changes it to not prompt. The default behavior when it's nonInteractive is to just not reformat. If this is incorrect behavior, we need --force instead.
